### PR TITLE
Add support for backup "standby" hosts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "fi.onesto.sbt"
 name := "sbt-mobilizer"
 
-version := "0.1.4-SNAPSHOT"
+version := "0.1.4"
 
 organizationName := "Onesto Services Oy"
 organizationHomepage := Option(new java.net.URL("http://onesto.fi"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "fi.onesto.sbt"
 name := "sbt-mobilizer"
 
-version := "0.1.3"
+version := "0.1.4-SNAPSHOT"
 
 organizationName := "Onesto Services Oy"
 organizationHomepage := Option(new java.net.URL("http://onesto.fi"))

--- a/src/main/scala/fi/onesto/sbt/mobilizer/Deployer.scala
+++ b/src/main/scala/fi/onesto/sbt/mobilizer/Deployer.scala
@@ -123,7 +123,7 @@ final class Deployer(
 
   private[this] def copyPackages(previousReleaseDirectories: Map[String, Option[String]]): Future[Unit] = {
     Future sequence {
-      for (hostname <- environment.hosts ++ environment.backupHosts) yield {
+      for (hostname <- environment.hosts ++ environment.standbyHosts) yield {
         Future {
           val target = s"$username@$hostname:$releaseDirectory/"
           logger.info(hostname, s"Copying package ${mainPackage.getName} to $releaseDirectory")
@@ -135,7 +135,7 @@ final class Deployer(
 
   private[this] def copyLibraries(previousReleaseDirectory: Map[String, Option[String]]): Future[Unit] = {
     Future sequence {
-      for (hostname <- environment.hosts ++ environment.backupHosts) yield {
+      for (hostname <- environment.hosts ++ environment.standbyHosts) yield {
         Future {
           val target = s"$username@$hostname:$libDirectory"
           val jars = libraries ++ dependencies
@@ -313,7 +313,7 @@ object Deployer {
 
   private[this] def openConnections(environment: DeploymentEnvironment)(implicit ec: ExecutionContext): Connections = {
     val eventualConnections = Future sequence {
-      environment.hosts ++ environment.backupHosts map { hostname =>
+      environment.hosts ++ environment.standbyHosts map { hostname =>
         for {
           client <- Future(connect(hostname, environment.username, environment.port))
           sftp   <- Future(client.newSFTPClient())

--- a/src/main/scala/fi/onesto/sbt/mobilizer/Deployer.scala
+++ b/src/main/scala/fi/onesto/sbt/mobilizer/Deployer.scala
@@ -123,7 +123,7 @@ final class Deployer(
 
   private[this] def copyPackages(previousReleaseDirectories: Map[String, Option[String]]): Future[Unit] = {
     Future sequence {
-      for (hostname <- environment.hosts) yield {
+      for (hostname <- environment.hosts ++ environment.backupHosts) yield {
         Future {
           val target = s"$username@$hostname:$releaseDirectory/"
           logger.info(hostname, s"Copying package ${mainPackage.getName} to $releaseDirectory")
@@ -135,7 +135,7 @@ final class Deployer(
 
   private[this] def copyLibraries(previousReleaseDirectory: Map[String, Option[String]]): Future[Unit] = {
     Future sequence {
-      for (hostname <- environment.hosts) yield {
+      for (hostname <- environment.hosts ++ environment.backupHosts) yield {
         Future {
           val target = s"$username@$hostname:$libDirectory"
           val jars = libraries ++ dependencies
@@ -313,7 +313,7 @@ object Deployer {
 
   private[this] def openConnections(environment: DeploymentEnvironment)(implicit ec: ExecutionContext): Connections = {
     val eventualConnections = Future sequence {
-      environment.hosts map { hostname =>
+      environment.hosts ++ environment.backupHosts map { hostname =>
         for {
           client <- Future(connect(hostname, environment.username, environment.port))
           sftp   <- Future(client.newSFTPClient())

--- a/src/main/scala/fi/onesto/sbt/mobilizer/DeploymentEnvironment.scala
+++ b/src/main/scala/fi/onesto/sbt/mobilizer/DeploymentEnvironment.scala
@@ -6,6 +6,7 @@ import net.schmizz.sshj.SSHClient
 
 final case class DeploymentEnvironment(
     hosts:                 Seq[String]    = Seq("localhost"),
+    backupHosts:           Seq[String]    = Seq.empty,
     port:                  Int            = SSHClient.DEFAULT_PORT,
     username:              String         = currentUser,
     rootDirectory:         String         = "/tmp/deploy",

--- a/src/main/scala/fi/onesto/sbt/mobilizer/DeploymentEnvironment.scala
+++ b/src/main/scala/fi/onesto/sbt/mobilizer/DeploymentEnvironment.scala
@@ -6,7 +6,7 @@ import net.schmizz.sshj.SSHClient
 
 final case class DeploymentEnvironment(
     hosts:                 Seq[String]    = Seq("localhost"),
-    backupHosts:           Seq[String]    = Seq.empty,
+    standbyHosts:          Seq[String]    = Seq.empty,
     port:                  Int            = SSHClient.DEFAULT_PORT,
     username:              String         = currentUser,
     rootDirectory:         String         = "/tmp/deploy",


### PR DESCRIPTION
Suppose you want to temporarily shut down an app running on server A
and move it to B. This requires running `stop` on A and `start` on B,
but without deploying this will start an old version on machine B. This
is easy to fix by altering the sbt settings to deploy on B instead and
running `deploy`. But not everybody can run `deploy` - system
specialists might only know about initctl and that's it.

To this end, this creates a `backupHosts` directive that will cause
libraries to be rsynced to those host **but not** started. So some
sysadmin can readily go and shut down the app on `hosts` and then
start them on `backupHosts`, and they will start the same version.